### PR TITLE
fix: Fix TypeError when incorrect response from API

### DIFF
--- a/index.js
+++ b/index.js
@@ -503,7 +503,7 @@ Mailchimp.prototype.request = function (options, done) {
       }
 
       if (response.statusCode < 200 || response.statusCode > 299) {
-        reject(Object.assign(new Error(response.body.detail), response.body));
+        reject(Object.assign(new Error(response.body ? response.body.detail : response.statusCode), response.body || response));
         return;
       }
 


### PR DESCRIPTION
TypeError: Cannot read property 'detail' of undefined
    at Request._callback (node_modules/mailchimp-api-v3/index.js:506:53)
    at Request.self.callback (node_modules/request/request.js:188:22)
    at emitTwo (events.js:106:13)
    at Request.emit (events.js:191:7)
    at Request.<anonymous> (node_modules/request/request.js:1171:10)
    at emitOne (events.js:96:13)
    at Request.emit (events.js:188:7)
    at IncomingMessage.<anonymous> (node_modules/request/request.js:1091:12)
    at IncomingMessage.g (events.js:292:16)
    at emitNone (events.js:91:20)
    at IncomingMessage.emit (events.js:185:7)
    at endReadableNT (_stream_readable.js:974:12)
    at _combinedTickCallback (internal/process/next_tick.js:80:11)
    at process._tickDomainCallback [as _tickCallback] (internal/process/next_tick.js:128:9)