### PR TITLE
provide typescript types for basic package

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,50 @@
+type Path = string;
+type Options = {};
+
+type PathOrOptions = Path | Options;
+
+type Query = string;
+type Callback = Function;
+
+type QueryOrCallback = Query | Callback;
+
+type Body = {}
+type BodyOrCallback = Body | Callback;
+
+declare module "mailchimp-api-v3" {
+  export interface IMailchimp {
+    get(
+      pathOrOptions: PathOrOptions,
+      queryOrCallback?: QueryOrCallback,
+      callback?: Callback,
+    ): Promise<any>;
+
+    post(
+      pathOrOptions: PathOrOptions,
+      bodyOrCallback?: BodyOrCallback,
+      callback?: Callback,
+    ): Promise<any>;
+
+    patch(
+      pathOrOptions: PathOrOptions,
+      bodyOrCallback?: BodyOrCallback,
+      callback?: Callback,
+    ): Promise<any>;
+
+    put(
+      pathOrOptions: PathOrOptions,
+      bodyOrCallback?: BodyOrCallback,
+      callback?: Callback,
+    ): Promise<any>;
+
+    delete(
+      pathOrOptions: PathOrOptions,
+      callback?: Callback,
+    ): Promise<any>;
+
+    request(
+      options: Options,
+      callback?: Callback,
+    ): Promise<any>;
+  }
+}


### PR DESCRIPTION
Hey there,

Currently if this code is used in a typescript project `tsc` will fail to build the project with the following error:

```
ERROR in ./mailer.ts
(1,28): error TS7016: Could not find a declaration file for module 'mailchimp-api-v3'. '/Users/ossareh/dev/src/code.famfi.co/mono/famfi.co/mailchimp/node_modules/mailchimp-api-v3/index.js' implicitly has an 'any' type.
```

The type file included in this PR is the minimum necessary to appease the type gods. Given how complex the mailchimp API responses can be (and the flexible nature of how you've setup this project) I opted against attempting to model it too far down and just do the minimum necessary to avoid the common errors.

I didn't include `batch()` because I've not had to use it yet.