### PR TITLE
latest lodash for https://snyk.io/vuln/SNYK-JS-LODASH-450202

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -327,9 +327,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "mime-db": {
       "version": "1.37.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailchimp-api-v3",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Mailchimp wrapper for v3 of the mailchimp api, with transparant handling of batch operations",
   "main": "index.js",
   "scripts": {
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/thorning/node-mailchimp#readme",
   "dependencies": {
     "bluebird": "^3.4.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.14",
     "request": "^2.88.0",
     "tar": "^4.0.2"
   },


### PR DESCRIPTION
This brings lodash to latest to address Prototype Pollution as noted in https://github.com/lodash/lodash/wiki/Changelog. This allows projects dependent on npm mailchimp-api-v3 to resolve the high severity vulnerability detected by `snyk test`