### PR TITLE
Add support for OAuth token and DC

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,16 +14,21 @@ Promise.config({
     }
 });
 
-function Mailchimp (api_key) {
+function Mailchimp (api_key, dc = null) {
   var api_key_regex = /.+\-.+/
 
-  if (!api_key_regex.test(api_key)) {
+  if (!api_key_regex.test(api_key) && dc === null) {
     throw new Error('missing or invalid api key: ' + api_key)
   }
 
 
   this.__api_key = api_key;
-  this.__base_url = "https://"+ this.__api_key.split('-')[1] + ".api.mailchimp.com/3.0"
+  if(dc !== null){
+    this.__base_url = "https://us"+ dc + ".api.mailchimp.com/3.0"
+    console.log(this.__base_url)
+  }else{
+    this.__base_url = "https://"+ this.__api_key.split('-')[1] + ".api.mailchimp.com/3.0"
+  }
 }
 
 var formatPath = function (path, path_params) {

--- a/index.js
+++ b/index.js
@@ -24,8 +24,7 @@ function Mailchimp (api_key, dc = null) {
 
   this.__api_key = api_key;
   if(dc !== null){
-    this.__base_url = "https://us"+ dc + ".api.mailchimp.com/3.0"
-    console.log(this.__base_url)
+    this.__base_url = "https://"+ dc + ".api.mailchimp.com/3.0"
   }else{
     this.__base_url = "https://"+ this.__api_key.split('-')[1] + ".api.mailchimp.com/3.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailchimp-api-v3",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Mailchimp wrapper for v3 of the mailchimp api, with transparant handling of batch operations",
   "main": "index.js",
   "scripts": {

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,5 +1,7 @@
 var api_key = process.env.MAILCHIMP_TEST_API_KEY
+var oauth_token = process.env.MAILCHIMP_TEST_OAUTH_TOKEN
 var assert = require('assert')
+var dc = process.env.DC
 
 var Mailchimp = require('../index');
 
@@ -25,11 +27,109 @@ describe('handle initialization', function () {
   it('should work for correctly formated api key', function () {
     var mailchimp = new Mailchimp('key-dc')
   })
+
+  it('should work for correctly formated oauth token with a DC', function () {
+    var mailchimp = new Mailchimp('token', '19')
+  })
 })
 
 describe('basic mailchimp api methods', function () {
 
   var mailchimp = new Mailchimp(api_key);
+
+  it('should handle simple get', function (done) {
+    mailchimp.get({
+      path : '/lists',
+    }, function (err, result) {
+      assert.equal(err, null);
+      assert.ok(result)
+      assert.ok(result.lists)
+      done()
+    })
+  })
+
+  it('should handle simple get with promise', function (done) {
+    mailchimp.get({
+      path : '/lists',
+    }).then(function (result) {
+      assert.ok(result)
+      assert.ok(result.lists)
+      done()
+    }).catch(function (err) {
+      done(new Error(err));
+    })
+  })
+
+  it('should handle wrong path', function (done) {
+    mailchimp.get({
+      path : '/wrong',
+    }, function (err, result) {
+      assert.equal(err.status, 404);
+      done()
+    })
+  })
+
+  it('should handle wrong path with promise', function (done) {
+    mailchimp.get({
+      path : '/wrong',
+    }).then(function (result) {
+      //Error
+      done(result)
+    }).catch(function (err) {
+      assert.equal(err.status, 404);
+      done()
+    })
+  })
+
+  it('should handle get with just a path', function (done) {
+    mailchimp.get('/lists', function (err, result) {
+      assert.equal(err, null);
+
+      assert.ok(result)
+      assert.ok(result.lists)
+      done()
+    })
+  })
+
+  it('should handle get with just a path with promise', function (done) {
+    mailchimp.get('/lists')
+      .then(function (result) {
+        assert.ok(result);
+        assert.ok(result.lists);
+        done();
+      })
+      .catch(function (err) {
+        done(new Error(err))
+      })
+  })
+
+  it('should handle get with a path and query', function (done) {
+    mailchimp.get('/lists', {offset : 1}, function (err, result) {
+      assert.equal(err, null);
+
+      assert.ok(result)
+      assert.ok(result.lists)
+      done()
+    })
+  })
+
+  it('should handle get with a path and query with promise', function (done) {
+    mailchimp.get('/lists', {offset : 1})
+      .then(function (result) {
+        assert.ok(result)
+        assert.ok(result.lists)
+        done()
+      })
+      .catch(function (err) {
+        done(new Error(err))
+      })
+  })
+
+})
+
+describe('basic mailchimp api methods with oauth token and dc', function () {
+
+  var mailchimp = new Mailchimp(oauth_token, dc);
 
   it('should handle simple get', function (done) {
     mailchimp.get({

--- a/test/basic.js
+++ b/test/basic.js
@@ -29,7 +29,7 @@ describe('handle initialization', function () {
   })
 
   it('should work for correctly formated oauth token with a DC', function () {
-    var mailchimp = new Mailchimp('token', '19')
+    var mailchimp = new Mailchimp('token', 'us19')
   })
 })
 


### PR DESCRIPTION
Background about Mailchimp's OAuth flow here:
https://mailchimp.com/developer/marketing/guides/access-user-data-oauth-2/

This pull request adds support for OAuth tokens. When navigating through the OAuth flow, the OAuth flow returns a token and a "dc" which is the datacenter that is attached to the base uri. We would like support for this in the node module. This adds an optional parameter called DC and utilizes the existing api_key field for the oauth token. The reason this change is small is because Mailchimp can use oauth tokens in basic http authentication. 