### PR TITLE
Update typings for oauth support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@
 export = Mailchimp;
 
 declare class Mailchimp {
-  constructor(api: string)
+  constructor(api: string, dc?: string)
 
   get(
     pathOrOptions: PathOrOptions,


### PR DESCRIPTION
As of #73, the constructor now takes an optional `dc` parameter, but the typings weren't updated to reflect this.

This causes errors when trying to use OAuth with typescript:

![image](https://user-images.githubusercontent.com/4368928/148292775-a92d2e7f-533b-4c11-9cff-6283d3b2dbf8.png)
